### PR TITLE
Add VirtualDJ plugin prototypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@
 DylanLanckman/DylanLanckman is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+## Prototypes
+
+Experimental VirtualDJ plugin prototypes are available in the
+[`prototypes`](prototypes/) directory.

--- a/prototypes/README.md
+++ b/prototypes/README.md
@@ -1,0 +1,18 @@
+# VirtualDJ Plugin Prototypes
+
+This directory contains experimental prototypes for a future VirtualDJ
+plugin that integrates with [Music Assistant](https://music-assistant.io).
+The goal is to expose a VirtualDJ instance as a smart speaker and to
+control Music Assistant media via MIDI controllers connected to
+VirtualDJ.
+
+## Components
+
+- `smart_speaker_advertiser.py` – broadcasts VirtualDJ on the local
+  network via Zeroconf as a placeholder smart speaker.
+- `midi_music_assistant_bridge.py` – listens to a MIDI controller and
+  issues Music Assistant API calls based on received messages.
+- `config_gui.py` – minimal Tkinter application for editing settings.
+
+These scripts are for demonstration purposes only and are **not** a
+complete plugin.

--- a/prototypes/config_gui.py
+++ b/prototypes/config_gui.py
@@ -1,0 +1,44 @@
+"""Prototype configuration GUI for the Virtual DJ plugin.
+
+The real plugin would expose a richer configuration interface inside
+Virtual DJ. This Tkinter example demonstrates how basic settings such as
+MIDI device selection and Music Assistant endpoint could be edited and
+stored in a JSON file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tkinter as tk
+from tkinter import ttk
+
+CONFIG_PATH = Path(__file__).with_name("config.json")
+
+
+class ConfigGUI(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("VirtualDJ Plugin Config")
+        tk.Label(self, text="Music Assistant URL").grid(row=0, column=0, sticky="w")
+        self.url_var = tk.StringVar(value="http://localhost:8095")
+        tk.Entry(self, textvariable=self.url_var, width=40).grid(row=0, column=1)
+        tk.Label(self, text="MIDI Device").grid(row=1, column=0, sticky="w")
+        self.device_var = tk.StringVar(value="default")
+        tk.Entry(self, textvariable=self.device_var, width=40).grid(row=1, column=1)
+        ttk.Button(self, text="Save", command=self.save).grid(
+            row=2, column=0, columnspan=2, pady=5
+        )
+
+    def save(self) -> None:
+        data = {
+            "music_assistant_url": self.url_var.get(),
+            "midi_device": self.device_var.get(),
+        }
+        CONFIG_PATH.write_text(json.dumps(data, indent=2))
+        self.destroy()
+
+
+if __name__ == "__main__":
+    app = ConfigGUI()
+    app.mainloop()

--- a/prototypes/midi_music_assistant_bridge.py
+++ b/prototypes/midi_music_assistant_bridge.py
@@ -1,0 +1,40 @@
+"""Prototype: Bridge MIDI controllers to Music Assistant commands.
+
+This script listens to the first available MIDI input device using the
+``mido`` library. When a Note On message is received it triggers a simple
+HTTP request to a hypothetical Music Assistant API. The mapping between
+MIDI messages and API endpoints can be extended to provide full control
+of Music Assistant from within Virtual DJ.
+"""
+
+from __future__ import annotations
+
+import mido
+import requests
+
+MUSIC_ASSISTANT_URL = "http://localhost:8095/api/media"
+
+
+def handle_message(msg: mido.Message) -> None:
+    """Handle incoming MIDI messages."""
+    if msg.type == "note_on" and msg.velocity > 0:
+        requests.post(f"{MUSIC_ASSISTANT_URL}/play", json={"note": msg.note})
+    elif msg.type == "control_change":
+        requests.post(
+            f"{MUSIC_ASSISTANT_URL}/control",
+            json={"control": msg.control, "value": msg.value},
+        )
+
+
+def main() -> None:
+    inputs = mido.get_input_names()
+    if not inputs:
+        raise RuntimeError("No MIDI input devices found")
+    with mido.open_input(inputs[0]) as inport:
+        print(f"Listening on {inputs[0]}")
+        for msg in inport:
+            handle_message(msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/requirements.txt
+++ b/prototypes/requirements.txt
@@ -1,0 +1,4 @@
+mido
+python-rtmidi
+requests
+zeroconf

--- a/prototypes/smart_speaker_advertiser.py
+++ b/prototypes/smart_speaker_advertiser.py
@@ -1,0 +1,51 @@
+"""Prototype: Advertises Virtual DJ as a network smart speaker.
+
+This module uses Zeroconf (mDNS/Bonjour) to broadcast a simple HTTP
+service representing the current Virtual DJ instance. In a full plugin
+this would be expanded to implement a real streaming protocol such as
+AirPlay or Chromecast. For now it only demonstrates network
+advertisement.
+"""
+
+from __future__ import annotations
+
+import socket
+from dataclasses import dataclass
+
+from zeroconf import ServiceInfo, Zeroconf
+
+
+@dataclass
+class VirtualDJSpeaker:
+    """Advertise the current machine as a smart speaker."""
+
+    name: str = "VirtualDJ Smart Speaker"
+    port: int = 8009
+
+    def __post_init__(self) -> None:
+        self.zeroconf = Zeroconf()
+        self.info = ServiceInfo(
+            "_http._tcp.local.",
+            f"{self.name}._http._tcp.local.",
+            addresses=[socket.inet_aton("127.0.0.1")],
+            port=self.port,
+            properties={b"vdj": b"1"},
+        )
+
+    def start(self) -> None:
+        """Start advertising the service."""
+        self.zeroconf.register_service(self.info)
+
+    def stop(self) -> None:
+        """Stop advertising and close Zeroconf."""
+        self.zeroconf.unregister_service(self.info)
+        self.zeroconf.close()
+
+
+if __name__ == "__main__":
+    speaker = VirtualDJSpeaker()
+    speaker.start()
+    try:
+        input("Advertising VirtualDJ... Press Enter to stop.\n")
+    finally:
+        speaker.stop()


### PR DESCRIPTION
## Summary
- add initial Python prototypes for a VirtualDJ smart speaker plugin
- demonstrate MIDI to Music Assistant bridge and simple configuration GUI
- document prototypes and dependencies

## Testing
- `python -m py_compile prototypes/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0806569248333b462f3b170b7a277