### PR TITLE
Add Virtual DJ Music Assistant plugin prototypes

### DIFF
--- a/prototypes/virtualdj_musicassistant/README.md
+++ b/prototypes/virtualdj_musicassistant/README.md
@@ -1,0 +1,9 @@
+# Virtual DJ Music Assistant Plugin Prototype
+
+This directory contains prototype code for a Virtual DJ plugin that integrates with Music Assistant. The prototypes are illustrative and not production-ready.
+
+## Components
+
+- `plugin_stub.cpp`: C++ skeleton for a Virtual DJ plugin exposing the instance as a smart speaker.
+- `bridge_stub.py`: Python bridge prototype between Virtual DJ and Music Assistant, forwarding MIDI events and audio.
+- `config_gui_stub.py`: Simple Tkinter GUI prototype for configuring connection settings.

--- a/prototypes/virtualdj_musicassistant/bridge_stub.py
+++ b/prototypes/virtualdj_musicassistant/bridge_stub.py
@@ -1,0 +1,29 @@
+"""
+Prototype Python bridge between Virtual DJ and Music Assistant.
+- Exposes Music Assistant as an audio output to Virtual DJ.
+- Forwards MIDI controller events to Music Assistant.
+"""
+
+import asyncio
+
+class MusicAssistantBridge:
+    def __init__(self, ma_url: str):
+        self.ma_url = ma_url  # Base URL of Music Assistant instance
+        # TODO: initialize MIDI and network connections
+
+    async def start(self):
+        """Start the bridge."""
+        # TODO: implement WebSocket connection to Music Assistant
+        # TODO: listen for MIDI events and forward to Music Assistant
+        pass
+
+    async def stop(self):
+        """Stop the bridge and clean up."""
+        pass
+
+if __name__ == "__main__":
+    bridge = MusicAssistantBridge("http://localhost:8080")
+    try:
+        asyncio.run(bridge.start())
+    except KeyboardInterrupt:
+        asyncio.run(bridge.stop())

--- a/prototypes/virtualdj_musicassistant/config_gui_stub.py
+++ b/prototypes/virtualdj_musicassistant/config_gui_stub.py
@@ -1,0 +1,24 @@
+"""
+Prototype configuration GUI for the Virtual DJ Music Assistant plugin.
+Provides simple interface to configure Music Assistant connection.
+"""
+
+import tkinter as tk
+from tkinter import ttk
+
+class ConfigGUI(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Music Assistant Plugin")
+        self.geometry("400x200")
+        ttk.Label(self, text="Music Assistant URL").pack(pady=10)
+        self.url_var = tk.StringVar(value="http://localhost:8080")
+        ttk.Entry(self, textvariable=self.url_var, width=40).pack()
+        ttk.Button(self, text="Save", command=self.save).pack(pady=20)
+
+    def save(self):
+        # TODO: persist configuration
+        print(f"Saved URL: {self.url_var.get()}")
+
+if __name__ == "__main__":
+    ConfigGUI().mainloop()

--- a/prototypes/virtualdj_musicassistant/plugin_stub.cpp
+++ b/prototypes/virtualdj_musicassistant/plugin_stub.cpp
@@ -1,0 +1,33 @@
+/**
+ * Prototype Virtual DJ plugin
+ * Exposes Virtual DJ instance as a smart speaker.
+ * TODO: Implement smart speaker discovery (e.g., mDNS, UPnP) and audio streaming.
+ */
+
+#include "vdjPlugin8.h"
+
+class MusicAssistantPlugin : public VdjPlugin8 {
+public:
+    HRESULT OnLoad() override {
+        // Initialize smart speaker interface
+        // TODO: start discovery service and register audio device
+        return S_OK;
+    }
+
+    ULONG OnStart() override {
+        // Called when plugin starts
+        // TODO: connect to Music Assistant backend
+        return 0;
+    }
+
+    void OnStop() override {
+        // Cleanup resources
+        // TODO: stop discovery service and disconnect
+    }
+};
+
+HRESULT __stdcall VDJPlugin8_GetInstance(VdjPlugin8 **instance) {
+    if (!instance) return E_POINTER;
+    *instance = new MusicAssistantPlugin();
+    return S_OK;
+}


### PR DESCRIPTION
## Summary
- add C++ plugin stub exposing Virtual DJ as smart speaker
- prototype Python bridge for MIDI and Music Assistant connection
- simple Tkinter GUI to configure plugin settings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0806569248333b462f3b170b7a277